### PR TITLE
Fixed build with GCC 13.x

### DIFF
--- a/src/kumir2-libs/vm/vm_breakpoints_table.hpp
+++ b/src/kumir2-libs/vm/vm_breakpoints_table.hpp
@@ -4,6 +4,7 @@
 #include <map>
 #include <utility>
 #include <string>
+#include <cstdint>
 
 namespace VM
 {

--- a/src/kumir2-libs/vm/vm_instruction.hpp
+++ b/src/kumir2-libs/vm/vm_instruction.hpp
@@ -2,6 +2,7 @@
 #define BYTECODEGENERATOR_INSTRUCTION_H
 
 #include <string>
+#include <cstdint>
 #include <map>
 #include <utility>
 


### PR DESCRIPTION
uint32_t is defined in cstdint header and requires include this header explicitly.